### PR TITLE
chore(example): add deno example

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,4 +43,7 @@ jobs:
 
       - uses: denoland/setup-deno@v1
       - name: Run deno example
-        run: deno run --allow-net deno-example/index.ts
+        run: deno run --allow-net deno-example/index.ts && deno run --allow-net deno-example/npm-index.ts
+
+      - name: Run deno example check
+        run: deno check deno-example/*.ts

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,3 +40,7 @@ jobs:
       - uses: oven-sh/setup-bun@v1
       - name: Run bun example
         run: cd bun-example && bun install && bun index.ts && bun build index.ts > /tmp/tmp.js
+
+      - uses: denoland/setup-deno@v1
+      - name: Run deno example
+        run: deno run --allow-net deno-example/index.ts

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "deno.enablePaths": ["./deno-example"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "deno.enablePaths": ["./deno-example"]
+  "deno.enablePaths": [
+    "./deno-example"
+  ],
+  "deno.enable": true
 }

--- a/README.md
+++ b/README.md
@@ -570,7 +570,7 @@ import {
 **Yes**, **xior** works anywhere where the native `fetch` API is supported.
 Even if the environment doesn't support `fetch`, you can use a `fetch` polyfill like for older browsers.
 
-> deno: check example `deno-example/index.ts`
+> deno: check example [deno-example/index.ts](./deno-example/index.ts)
 
 ### 3. How do I handle responses with types like `'stream'`, `'document'`, `'arraybuffer'`, or `'blob'`?
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A request lib based on **fetch** with plugins support.
 - [Helper functions](#helper-functions)
 - [FAQ](#faq)
   - [1. Is **xior** 100% compatiable with `axios`?](#1-is-xior-100-compatiable-with-axios)
-  - [2. Can I use xior in projects like Bun, Expo, React Native, Next.js, Vue, or Nuxt.js?](#2-can-i-use-xior-in-projects-like-bun-expo-react-native-nextjs-vue-or-nuxtjs)
+  - [2. Can I use xior in projects like Deno, Bun, Expo, React Native, Next.js, Vue, or Nuxt.js?](#2-can-i-use-xior-in-projects-like-deno-bun-expo-react-native-nextjs-vue-or-nuxtjs)
   - [3. How do I handle responses with types like `'stream'`, `'document'`, `'arraybuffer'`, or `'blob'`?](#3-how-do-i-handle-responses-with-types-like-stream-document-arraybuffer-or-blob)
   - [5. How do I support older browsers?](#5-how-do-i-support-older-browsers)
   - [6. Why is xior named "xior"?](#6-why-is-xior-named-xior)
@@ -565,10 +565,12 @@ import {
 
 **No**, but **xior** offers a similar API like axios: `axios.create` / `axios.interceptors` / `.get/post/put/patch/delete/head/options`.
 
-### 2. Can I use xior in projects like Bun, Expo, React Native, Next.js, Vue, or Nuxt.js?
+### 2. Can I use xior in projects like Deno, Bun, Expo, React Native, Next.js, Vue, or Nuxt.js?
 
 **Yes**, **xior** works anywhere where the native `fetch` API is supported.
 Even if the environment doesn't support `fetch`, you can use a `fetch` polyfill like for older browsers.
+
+> deno: check example `deno-example/index.ts`
 
 ### 3. How do I handle responses with types like `'stream'`, `'document'`, `'arraybuffer'`, or `'blob'`?
 

--- a/deno-example/index.ts
+++ b/deno-example/index.ts
@@ -1,0 +1,28 @@
+import xior from 'https://esm.sh/xior@0.0.7';
+import cachePlugin from 'https://esm.sh/xior@0.0.7/plugins/cache';
+import errorRetryPlugin from 'https://esm.sh/xior@0.0.7/plugins/error-retry';
+import uploadDownloadProgressPlugin from 'https://esm.sh/xior@0.0.7/plugins/progress';
+import throttlePlugin from 'https://esm.sh/xior@0.0.7/plugins/throttle';
+
+console.log('hi xior from deno', xior);
+
+const instance = xior.create();
+instance.plugins.use(errorRetryPlugin({}));
+instance.plugins.use(cachePlugin({}));
+instance.plugins.use(throttlePlugin({}));
+instance.plugins.use(uploadDownloadProgressPlugin({}));
+
+instance.plugins.use((adapter) => {
+  return async (config) => {
+    const res = await adapter(config);
+    console.log(`%s %s -> %s`, config.method, config.url, res.status);
+    return res;
+  };
+});
+
+instance.get('https://google.com', {
+  progressDuration: 500,
+  onDownloadProgress(e) {
+    console.log(`Download %s%`, e.progress);
+  },
+});

--- a/deno-example/npm-index.ts
+++ b/deno-example/npm-index.ts
@@ -1,0 +1,27 @@
+import xior, { merge, delay, buildSortedURL, encodeParams } from 'npm:xior';
+import cachePlugin from 'npm:xior/plugins/cache';
+import errorRetryPlugin from 'npm:xior/plugins/error-retry';
+import uploadDownloadProgressPlugin from 'npm:xior/plugins/progress';
+import throttlePlugin from 'npm:xior/plugins/throttle';
+
+// console.log(merge, delay, buildSortedURL);
+const instance = xior.create({});
+instance.plugins.use(errorRetryPlugin({}));
+instance.plugins.use(cachePlugin({}));
+instance.plugins.use(throttlePlugin({}));
+instance.plugins.use(uploadDownloadProgressPlugin({}));
+
+instance.plugins.use((adapter) => {
+  return async (config) => {
+    const res = await adapter(config);
+    console.log(`%s %s -> %s`, config.method, config.url, res.status);
+    return res;
+  };
+});
+
+instance.get('https://google.com', {
+  progressDuration: 500,
+  onDownloadProgress(e) {
+    console.log(`Download %s%`, e.progress);
+  },
+});

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "start-publish": "pnpm build && pnpm test && npm publish --registry=https://registry.npmjs.org",
     "push": "git push && git lfs push --all origin",
     "prepare": "is-ci || pnpm build && husky",
-    "checksize": "pnpm --filter=vite-example build"
+    "checksize": "pnpm --filter=vite-example build",
+    "run:deno-example": "deno run --allow-net deno-example/index.ts"
   },
   "dependencies": {
     "ts-deepmerge": "^7.0.0",


### PR DESCRIPTION
Work fine with deno, but plugin's types that extend `xior` request config not work:


<img width="888" alt="image" src="https://github.com/denoland/deno/assets/6512574/9e812497-f57a-46f4-b43e-c21f6bbc2627">