### PR TITLE
Response type blob arrarybuffer and add same multiple response interceptors chain behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG 📝
 
+## v0.4.0 2024/04/24
+
+**Breaking Change**
+
+This version is about Axios compatible issue in some cases. Fixing https://github.com/suhaotian/xior/issues/12 and https://github.com/suhaotian/xior/issues/15.
+
+- Feat(core): when `responseType: 'blob' | 'arrarybuffer'` then the `resposne.data` is `Blob` and `ArrayBuffer`, no need `response.blob()` or `response.arraybuffer()` anymore.
+- Fix(interceptors): make sure the multiple response interceptors chain behaviour same as axios's interceptors.
+
 ## v0.3.13 2024/04/21
 
 - Feat(plugin): add custom paramaters of LRU in plugins: cache, error-cache, throttle

--- a/Mock-plugin.md
+++ b/Mock-plugin.md
@@ -61,8 +61,8 @@ instance.get('/api/hello').then((res) => {
 Using jsDelivr CDN:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/xior@0.3.13/dist/xior.umd.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/xior@0.3.13/plugins/mock.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xior@0.4.0/dist/xior.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xior@0.4.0/plugins/mock.umd.js"></script>
 
 <!-- Usage -->
 <script>
@@ -79,8 +79,8 @@ Using jsDelivr CDN:
 Using unpkg CDN:
 
 ```html
-<script src="https://unpkg.com/xior@0.3.13/dist/xior.umd.js"></script>
-<script src="https://unpkg.com/xior@0.3.13/plugins/mock.umd.js"></script>
+<script src="https://unpkg.com/xior@0.4.0/dist/xior.umd.js"></script>
+<script src="https://unpkg.com/xior@0.4.0/plugins/mock.umd.js"></script>
 
 <!-- Usage -->
 <script>

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ yarn add xior
 Use jsDelivr CDN:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/xior@0.3.13/dist/xior.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xior@0.4.0/dist/xior.umd.js"></script>
 
 <!-- Usage -->
 <script>
@@ -136,7 +136,7 @@ Use jsDelivr CDN:
 Use unpkg CDN:
 
 ```html
-<script src="https://unpkg.com/xior@0.3.13/dist/xior.umd.js"></script>
+<script src="https://unpkg.com/xior@0.4.0/dist/xior.umd.js"></script>
 
 <!-- Usage -->
 <script>
@@ -316,6 +316,7 @@ http.interceptors.response.use(
     if (error?.response?.status === 401) {
       localStorage.removeItem('REQUEST_TOKEN');
     }
+    return Promise.reject(error);
   }
 );
 ```
@@ -659,9 +660,9 @@ Use CDN:
 Using jsDelivr CDN:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/xior@0.3.13/dist/xior.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xior@0.4.0/dist/xior.umd.js"></script>
 <!-- Load plugin -->
-<script src="https://cdn.jsdelivr.net/npm/xior@0.3.13/plugins/error-retry.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xior@0.4.0/plugins/error-retry.umd.js"></script>
 
 <!-- Usage -->
 <script>
@@ -674,10 +675,10 @@ Using jsDelivr CDN:
 Using unpkg CDN:
 
 ```html
-<script src="https://unpkg.com/xior@0.3.13/dist/xior.umd.js"></script>
+<script src="https://unpkg.com/xior@0.4.0/dist/xior.umd.js"></script>
 
 <!-- Load plugin -->
-<script src="https://unpkg.com/xior@0.3.13/plugins/error-retry.umd.js"></script>
+<script src="https://unpkg.com/xior@0.4.0/plugins/error-retry.umd.js"></script>
 
 <!-- Usage -->
 <script>
@@ -770,9 +771,9 @@ Use CDN:
 Using jsDelivr CDN:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/xior@0.3.13/dist/xior.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xior@0.4.0/dist/xior.umd.js"></script>
 <!-- Load plugin -->
-<script src="https://cdn.jsdelivr.net/npm/xior@0.3.13/plugins/throttle.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xior@0.4.0/plugins/throttle.umd.js"></script>
 
 <!-- Usage -->
 <script>
@@ -785,10 +786,10 @@ Using jsDelivr CDN:
 Using unpkg CDN:
 
 ```html
-<script src="https://unpkg.com/xior@0.3.13/dist/xior.umd.js"></script>
+<script src="https://unpkg.com/xior@0.4.0/dist/xior.umd.js"></script>
 
 <!-- Load plugin -->
-<script src="https://unpkg.com/xior@0.3.13/plugins/throttle.umd.js"></script>
+<script src="https://unpkg.com/xior@0.4.0/plugins/throttle.umd.js"></script>
 
 <!-- Usage -->
 <script>
@@ -843,9 +844,9 @@ Use CDN:
 Using jsDelivr CDN:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/xior@0.3.13/dist/xior.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xior@0.4.0/dist/xior.umd.js"></script>
 <!-- Load plugin -->
-<script src="https://cdn.jsdelivr.net/npm/xior@0.3.13/plugins/dedupe.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xior@0.4.0/plugins/dedupe.umd.js"></script>
 
 <!-- Usage -->
 <script>
@@ -858,10 +859,10 @@ Using jsDelivr CDN:
 Using unpkg CDN:
 
 ```html
-<script src="https://unpkg.com/xior@0.3.13/dist/xior.umd.js"></script>
+<script src="https://unpkg.com/xior@0.4.0/dist/xior.umd.js"></script>
 
 <!-- Load plugin -->
-<script src="https://unpkg.com/xior@0.3.13/plugins/dedupe.umd.js"></script>
+<script src="https://unpkg.com/xior@0.4.0/plugins/dedupe.umd.js"></script>
 
 <!-- Usage -->
 <script>
@@ -923,9 +924,9 @@ Use CDN:
 Using jsDelivr CDN:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/xior@0.3.13/dist/xior.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xior@0.4.0/dist/xior.umd.js"></script>
 <!-- Load plugin -->
-<script src="https://cdn.jsdelivr.net/npm/xior@0.3.13/plugins/error-cache.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xior@0.4.0/plugins/error-cache.umd.js"></script>
 
 <!-- Usage -->
 <script>
@@ -938,10 +939,10 @@ Using jsDelivr CDN:
 Using unpkg CDN:
 
 ```html
-<script src="https://unpkg.com/xior@0.3.13/dist/xior.umd.js"></script>
+<script src="https://unpkg.com/xior@0.4.0/dist/xior.umd.js"></script>
 
 <!-- Load plugin -->
-<script src="https://unpkg.com/xior@0.3.13/plugins/error-cache.umd.js"></script>
+<script src="https://unpkg.com/xior@0.4.0/plugins/error-cache.umd.js"></script>
 
 <!-- Usage -->
 <script>
@@ -1086,9 +1087,9 @@ Use CDN:
 Using jsDelivr CDN:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/xior@0.3.13/dist/xior.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xior@0.4.0/dist/xior.umd.js"></script>
 <!-- Load plugin -->
-<script src="https://cdn.jsdelivr.net/npm/xior@0.3.13/plugins/progress.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xior@0.4.0/plugins/progress.umd.js"></script>
 
 <!-- Usage -->
 <script>
@@ -1101,10 +1102,10 @@ Using jsDelivr CDN:
 Using unpkg CDN:
 
 ```html
-<script src="https://unpkg.com/xior@0.3.13/dist/xior.umd.js"></script>
+<script src="https://unpkg.com/xior@0.4.0/dist/xior.umd.js"></script>
 
 <!-- Load plugin -->
-<script src="https://unpkg.com/xior@0.3.13/plugins/progress.umd.js"></script>
+<script src="https://unpkg.com/xior@0.4.0/plugins/progress.umd.js"></script>
 
 <!-- Usage -->
 <script>
@@ -1211,9 +1212,9 @@ Use CDN:
 Using jsDelivr CDN:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/xior@0.3.13/dist/xior.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xior@0.4.0/dist/xior.umd.js"></script>
 <!-- Load plugin -->
-<script src="https://cdn.jsdelivr.net/npm/xior@0.3.13/plugins/mock.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xior@0.4.0/plugins/mock.umd.js"></script>
 
 <!-- Usage -->
 <script>
@@ -1226,10 +1227,10 @@ Using jsDelivr CDN:
 Using unpkg CDN:
 
 ```html
-<script src="https://unpkg.com/xior@0.3.13/dist/xior.umd.js"></script>
+<script src="https://unpkg.com/xior@0.4.0/dist/xior.umd.js"></script>
 
 <!-- Load plugin -->
-<script src="https://unpkg.com/xior@0.3.13/plugins/mock.umd.js"></script>
+<script src="https://unpkg.com/xior@0.4.0/plugins/mock.umd.js"></script>
 
 <!-- Usage -->
 <script>
@@ -1336,7 +1337,35 @@ Even if the environment doesn't support `fetch`, you can use a `fetch` polyfill 
 
 ### 3. How do I handle responses with types like `'stream'`, `'document'`, `'arraybuffer'`, or `'blob'`?
 
-> Currently in `xior`, when `responseType` is set to `'stream', 'document', 'arraybuffer', 'blob', or 'original'`, Xior will return the original fetch response.
+When `{responseType: 'blob'| 'arraybuffer'}`:
+
+```ts
+xior.get('https://exmaple.com/some/api', { responseType: 'blob' }).then((response) => {
+  console.log(response.data); // response.data is a Blob
+});
+
+// Same with
+fetch('https://exmaple.com/some/api')
+  .then((response) => response.blob())
+  .then((data) => {
+    console.log(data); // is a Blob
+  });
+```
+
+```ts
+xior.get('https://exmaple.com/some/api', { responseType: 'arraybuffer' }).then((response) => {
+  console.log(response.data); // response.data is a ArrayBuffer
+});
+
+// Same with
+fetch('https://exmaple.com/some/api')
+  .then((response) => response.arraybuffer())
+  .then((data) => {
+    console.log(data); // is a ArrayBuffer
+  });
+```
+
+**But when `responseType` set to `'stream', 'document' or 'original'`, Xior will return the original fetch response:**
 
 ```ts
 fetch('https://exmaple.com/some/api').then((response) => {
@@ -1344,8 +1373,8 @@ fetch('https://exmaple.com/some/api').then((response) => {
 });
 
 // same with
-xior.get('https://exmaple.com/some/api', { responseType: 'blob' }).then((res) => {
-  console.log(res.response); // res.data will be undefined
+xior.get('https://exmaple.com/some/api', { responseType: 'stream' }).then((res) => {
+  console.log(res.response); // But res.data will be undefined
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xior",
-  "version": "0.3.13",
+  "version": "0.4.0",
   "description": "A lite request lib based on fetch with plugin support and similar API to axios.",
   "repository": "suhaotian/xior",
   "bugs": "https://github.com/suhaotian/xior/issues",

--- a/src/interceptors.ts
+++ b/src/interceptors.ts
@@ -58,10 +58,10 @@ export default async function defaultRequestInterceptor(req: XiorInterceptorRequ
 
   return {
     ...req,
-    data,
     _data,
-    url,
     _url,
+    data,
+    url,
     method,
     headers,
     isGet,

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,3 +46,20 @@ export type XiorPlugin = (
   adapter: (request: XiorRequestConfig) => Promise<XiorResponse>,
   instance?: XiorInstance
 ) => (request: XiorRequestConfig) => Promise<XiorResponse<any>>;
+
+export interface XiorInterceptorOptions {
+  /** @deprecated useless here */
+  synchronous?: boolean;
+  /** @deprecated useless here */
+  runWhen?: (config: XiorInterceptorRequestConfig) => boolean;
+}
+
+export interface XiorResponseInterceptorConfig<T = any> {
+  data: T;
+  config: XiorInterceptorRequestConfig<T>;
+  request: XiorInterceptorRequestConfig<T>;
+  response: Response;
+  status: number;
+  statusText: string;
+  headers: Headers;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,7 +69,7 @@ export class XiorError extends Error {
 
   constructor(message: string, request?: XiorRequestConfig, response?: XiorResponse) {
     super(message);
-    this.name = 'XiorError';
+    this.name = 'XError';
     this.request = request;
     this.config = request;
     this.response = response;
@@ -78,7 +78,7 @@ export class XiorError extends Error {
 export class XiorTimeoutError extends XiorError {
   constructor(message: string, request?: XiorRequestConfig, response?: XiorResponse) {
     super(message);
-    this.name = 'XiorTimeoutError';
+    this.name = 'XTimeoutError';
     this.request = request;
     this.config = request;
     this.response = response;
@@ -86,5 +86,5 @@ export class XiorTimeoutError extends XiorError {
 }
 
 export function isXiorError(error: any) {
-  return error.name === 'XiorError' || error.name === 'XiorTimeoutError';
+  return error.name === 'XError' || error.name === 'XTimeoutError';
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,7 +69,7 @@ export class XiorError extends Error {
 
   constructor(message: string, request?: XiorRequestConfig, response?: XiorResponse) {
     super(message);
-    this.name = 'XError';
+    this.name = 'XiorError';
     this.request = request;
     this.config = request;
     this.response = response;
@@ -78,7 +78,7 @@ export class XiorError extends Error {
 export class XiorTimeoutError extends XiorError {
   constructor(message: string, request?: XiorRequestConfig, response?: XiorResponse) {
     super(message);
-    this.name = 'XTimeoutError';
+    this.name = 'XiorTimeoutError';
     this.request = request;
     this.config = request;
     this.response = response;
@@ -86,5 +86,5 @@ export class XiorTimeoutError extends XiorError {
 }
 
 export function isXiorError(error: any) {
-  return error.name === 'XError' || error.name === 'XTimeoutError';
+  return error.name === 'XiorError' || error.name === 'XiorTimeoutError';
 }

--- a/src/xior.ts
+++ b/src/xior.ts
@@ -49,7 +49,7 @@ export class xior {
   static create(options?: XiorRequestConfig): XiorInstance {
     return new xior(options);
   }
-  static VERSION = '0.3.13';
+  static VERSION = '0.4.0';
 
   config?: XiorRequestConfig;
   defaults: XiorInterceptorRequestConfig;
@@ -71,7 +71,8 @@ export class xior {
     fn: (
       config: XiorResponseInterceptorConfig
     ) => Promise<XiorResponseInterceptorConfig> | XiorResponseInterceptorConfig;
-    onRejected?: null | ((error: XiorError | Error | TypeError) => any);
+    /** error: XiorError | Error | TypeError */
+    onRejected?: null | ((error: XiorError) => any);
   }[] = [];
 
   get interceptors() {
@@ -104,7 +105,8 @@ export class xior {
           fn: (
             config: XiorResponseInterceptorConfig
           ) => Promise<XiorResponseInterceptorConfig> | XiorResponseInterceptorConfig,
-          onRejected?: null | ((error: XiorError | Error | TypeError) => any)
+          /** error: XiorError | Error | TypeError */
+          onRejected?: null | ((error: XiorError) => any)
         ) => {
           this.RESI.push({ fn, onRejected });
           return fn;

--- a/tests/src/tests/axios-compatible.test.ts
+++ b/tests/src/tests/axios-compatible.test.ts
@@ -498,7 +498,7 @@ describe('axios compatible tests', () => {
       //
     });
     assert.strictEqual(xiorHasError, true);
-    assert.strictEqual(xiorError.request?.url, '/400');
-    assert.strictEqual(xiorError.response?.config.url, '/400');
+    assert.strictEqual(xiorError.request?.url, baseURL + '/400');
+    assert.strictEqual(xiorError.response?.config.url, baseURL + '/400');
   });
 });

--- a/tests/src/tests/axios-compatible.test.ts
+++ b/tests/src/tests/axios-compatible.test.ts
@@ -498,7 +498,7 @@ describe('axios compatible tests', () => {
       //
     });
     assert.strictEqual(xiorHasError, true);
-    assert.strictEqual(xiorError.request?.url, baseURL + '/400');
-    assert.strictEqual(xiorError.response?.config.url, baseURL + '/400');
+    assert.strictEqual(xiorError.request?.url, '/400');
+    assert.strictEqual(xiorError.response?.config.url, '/400');
   });
 });

--- a/tests/src/tests/index.test.ts
+++ b/tests/src/tests/index.test.ts
@@ -121,9 +121,8 @@ describe('xior tests', () => {
     });
 
     it('HEAD should work', async () => {
-      const { data, response } = await xiorInstance.head('/head', { params: { a: 1, b: 2 } });
-      assert.strictEqual(data, undefined);
-      assert.strictEqual(await response.text(), '');
+      const { data } = await xiorInstance.head('/head', { params: { a: 1, b: 2 } });
+      assert.strictEqual(data, '');
     });
 
     it('OPTIONS should work', async () => {
@@ -578,6 +577,7 @@ describe('xior tests', () => {
         },
         function (error) {
           catchFetchFailedError = error instanceof TypeError;
+          return Promise.reject(error);
         }
       );
       xiorInstance.plugins.use(

--- a/tests/src/tests/index.test.ts
+++ b/tests/src/tests/index.test.ts
@@ -390,6 +390,53 @@ describe('xior tests', () => {
     });
   });
 
+  describe('`responseType` should work', () => {
+    it('should work with `responseType: "blob"`', async () => {
+      const xiorInstance = xior.create({ baseURL });
+      const { data: getData } = await xiorInstance.get<Blob>('/get', {
+        responseType: 'blob',
+      });
+      assert.strictEqual(getData instanceof Blob, true);
+
+      const { data: postData } = await xiorInstance.post<Blob>(
+        '/post',
+        {},
+        { responseType: 'blob' }
+      );
+      assert.strictEqual(postData instanceof Blob, true);
+    });
+
+    it('should work with `responseType: "arraybuffer"`', async () => {
+      const xiorInstance = xior.create({ baseURL });
+      const { data: getData } = await xiorInstance.get<ArrayBuffer>('/get', {
+        responseType: 'arraybuffer',
+      });
+      assert.strictEqual(getData instanceof ArrayBuffer, true);
+
+      const { data: postData } = await xiorInstance.post<ArrayBuffer>(
+        '/post',
+        {},
+        { responseType: 'arraybuffer' }
+      );
+      assert.strictEqual(postData instanceof ArrayBuffer, true);
+    });
+
+    it('should work with as expected `responseType: "original"` or `responseType: "stream"`', async () => {
+      const xiorInstance = xior.create({ baseURL });
+      const { data: getData } = await xiorInstance.get<ArrayBuffer>('/get', {
+        responseType: 'original',
+      });
+      assert.strictEqual(getData === undefined, true);
+
+      const { data: postData } = await xiorInstance.post<ArrayBuffer>(
+        '/post',
+        {},
+        { responseType: 'stream' }
+      );
+      assert.strictEqual(postData === undefined, true);
+    });
+  });
+
   describe('custom plugins should work', () => {
     it('should work with custom plugin', async () => {
       const xiorInstance = xior.create({ baseURL });

--- a/tests/src/tests/interceptors.test.ts
+++ b/tests/src/tests/interceptors.test.ts
@@ -294,55 +294,6 @@ describe('interceptors', function () {
     assert.equal(response?.data, 'get13');
   });
 
-  // it('should remove async interceptor before making request and execute synchronously', function (done) {
-  //   let asyncFlag = false;
-  //   const asyncIntercept = axios.interceptors.request.use(
-  //     function (config) {
-  //       config.headers.async = 'async it!';
-  //       return config;
-  //     },
-  //     null,
-  //     { synchronous: false }
-  //   );
-
-  //   const syncIntercept = axios.interceptors.request.use(
-  //     function (config) {
-  //       config.headers.sync = 'hello world';
-  //       expect(asyncFlag).toBe(false);
-  //       return config;
-  //     },
-  //     null,
-  //     { synchronous: true }
-  //   );
-
-  //   axios.interceptors.request.eject(asyncIntercept);
-
-  //   axios('/foo');
-  //   asyncFlag = true;
-
-  //   getAjaxRequest().then(function (request) {
-  //     expect(request.requestHeaders.async).toBeUndefined();
-  //     expect(request.requestHeaders.sync).toBe('hello world');
-  //     done();
-  //   });
-  // });
-
-  // it('should execute interceptors before transformers', async function () {
-  //   axios.interceptors.request.use(function (config) {
-  //     config.data.baz = 'qux';
-  //     return config;
-  //   });
-
-  //   const {config: request} = await  axios.post('/post', {
-  //     foo: 'bar',
-  //   });
-
-  //   getAjaxRequest().then(function (request) {
-  //     expect(request.params).toEqual('{"foo":"bar","baz":"qux"}');
-  //     ();
-  //   });
-  // });
-
   it('should modify base URL in request interceptor', async function () {
     const instance = xior.create({
       baseURL: 'http://test.com/',

--- a/tests/src/tests/interceptors.test.ts
+++ b/tests/src/tests/interceptors.test.ts
@@ -306,7 +306,7 @@ describe('interceptors', function () {
 
     await instance.get('/get').then(({ config: request }) => {
       assert.equal(request.baseURL, baseURL);
-      assert.equal(request.url, baseURL + '/get');
+      assert.equal(request.url, '/get');
     });
   });
 

--- a/tests/src/tests/interceptors.test.ts
+++ b/tests/src/tests/interceptors.test.ts
@@ -306,7 +306,7 @@ describe('interceptors', function () {
 
     await instance.get('/get').then(({ config: request }) => {
       assert.equal(request.baseURL, baseURL);
-      assert.equal(request.url, '/get');
+      assert.equal(request.url, baseURL + '/get');
     });
   });
 

--- a/tests/src/tests/interceptors.test.ts
+++ b/tests/src/tests/interceptors.test.ts
@@ -1,0 +1,373 @@
+import assert from 'node:assert';
+import { after, afterEach, before, describe, it } from 'node:test';
+import xior, { XiorResponse } from 'xior';
+
+import { startServer } from './server';
+
+const axios = xior.create();
+
+let close: Function;
+const port = 7868;
+const baseURL = `http://localhost:${port}`;
+axios.defaults.baseURL = baseURL;
+before(async () => {
+  close = await startServer(port);
+});
+
+after(async () => {
+  return close(1);
+});
+
+afterEach(function () {
+  axios.interceptors.request.clear();
+  axios.interceptors.response.clear();
+});
+describe('interceptors', function () {
+  it('should execute asynchronously when not all interceptors are explicitly flagged as synchronous', async function () {
+    axios.interceptors.request.use(async function (config) {
+      config.headers.foo = 'uh oh, async';
+
+      return config;
+    });
+
+    axios.interceptors.request.use(async function (config) {
+      config.headers.test = 'added by the async interceptor';
+      return config;
+    });
+
+    const { config } = await axios.request('/get');
+    assert.equal(config.headers.foo, 'uh oh, async');
+    assert.equal(config.headers.test, 'added by the async interceptor');
+  });
+
+  it('should add a request interceptor that returns a promise', async function (done) {
+    axios.interceptors.request.use(function (config) {
+      return new Promise(function (resolve) {
+        // do something async
+        setTimeout(function () {
+          config.headers.async = 'promise';
+          resolve(config);
+        }, 100);
+      });
+    });
+
+    await axios.request('/get').then(({ config: request }) => {
+      assert.equal(request.headers.async, 'promise');
+    });
+  });
+
+  it('should add multiple request interceptors', function (done) {
+    axios.interceptors.request.use(function (config) {
+      config.headers.test1 = '1';
+      return config;
+    });
+    axios.interceptors.request.use(function (config) {
+      config.headers.test2 = '2';
+      return config;
+    });
+    axios.interceptors.request.use(function (config) {
+      config.headers.test3 = '3';
+      return config;
+    });
+
+    axios.request('/get').then(({ config: request }) => {
+      assert.equal(request.headers.test1, '1');
+      assert.equal(request.headers.test2, '2');
+      assert.equal(request.headers.test3, '3');
+    });
+  });
+
+  it('should add a response interceptor', async function () {
+    let response: XiorResponse | undefined;
+
+    axios.interceptors.response.use(function (data) {
+      data.data = data.data.method + ' - modified by interceptor';
+      return data;
+    });
+
+    await axios.request('/get').then(function (data) {
+      response = data;
+    });
+
+    assert.equal(response?.data, 'get - modified by interceptor');
+  });
+
+  it('should add a response interceptor when request interceptor is defined', async function () {
+    let response: XiorResponse | undefined;
+
+    axios.interceptors.request.use(function (config) {
+      return config;
+    });
+
+    axios.interceptors.response.use(function (data) {
+      data.data = data.data.method + ' - modified by interceptor';
+      return data;
+    });
+
+    await axios.request('/get').then(function (data) {
+      response = data;
+    });
+
+    assert.equal(response?.data, 'get - modified by interceptor');
+  });
+
+  it('should add a response interceptor that returns a new data object', async function () {
+    let response: XiorResponse | undefined;
+
+    axios.interceptors.response.use(function () {
+      return {
+        data: 'stuff',
+      } as any;
+    });
+
+    await axios.request('/get').then(function (data) {
+      response = data;
+    });
+    assert.equal(response?.data, 'stuff');
+  });
+
+  it('should add a response interceptor that returns a promise', async function () {
+    let response: XiorResponse | undefined;
+
+    axios.interceptors.response.use(function (data) {
+      return new Promise(function (resolve) {
+        // do something async
+        setTimeout(function () {
+          data.data = 'you have been promised!';
+          resolve(data);
+        }, 10);
+      });
+    });
+
+    await axios.request('/get').then(function (data) {
+      response = data;
+    });
+    assert.equal(response?.data, 'you have been promised!');
+  });
+
+  describe('given you add multiple response interceptors', function () {
+    describe('and when the response was fulfilled', function () {
+      it('then each interceptor is executed', async function () {
+        let fired1 = 0;
+        axios.interceptors.response.use((r) => {
+          fired1 = 1;
+          return r;
+        });
+        let fired2 = 0;
+        axios.interceptors.response.use((r) => {
+          fired2 = 2;
+          return r;
+        });
+        await axios.get('/get');
+        assert.equal(fired1, 1);
+        assert.equal(fired2, 2);
+      });
+
+      it('then they are executed in the order they were added', async function () {
+        const fired = [] as number[];
+        axios.interceptors.response.use((r) => {
+          fired.push(1);
+          return r;
+        });
+        axios.interceptors.response.use((r) => {
+          fired.push(2);
+          return r;
+        });
+        await axios.get('/get');
+        assert.equal(fired[1] > fired[0], true);
+      });
+
+      it("then only the last interceptor's result is returned", async function () {
+        axios.interceptors.response.use(function () {
+          return 'response 1' as any;
+        });
+        axios.interceptors.response.use(function (response) {
+          return 'response 2' as any;
+        });
+        const res = await axios.get('/get');
+        assert.equal(res as any, 'response 2');
+      });
+
+      it("then every interceptor receives the result of it's predecessor", async function () {
+        axios.interceptors.response.use(function () {
+          return 'response 1' as any;
+        });
+        axios.interceptors.response.use(function (response) {
+          return [response, 'response 2'] as any;
+        });
+        const res = await axios.get('/get');
+        assert.equal((res as any).join(','), ['response 1', 'response 2'].join(','));
+      });
+
+      describe('and when the fulfillment-interceptor throws', function () {
+        it('then the following fulfillment-interceptor is not called', async function () {
+          axios.interceptors.response.use(function () {
+            throw Error('throwing interceptor');
+          });
+
+          let fired = false;
+          axios.interceptors.response.use(async function interceptor2(config) {
+            fired = true;
+            return config;
+          });
+
+          try {
+            await axios.get('/get');
+          } catch (e) {
+            //
+          }
+          assert.equal(fired, false);
+        });
+
+        it('then the following rejection-interceptor is called', async function () {
+          axios.interceptors.response.use(function () {
+            throw Error('throwing interceptor');
+          });
+          const unusedFulfillInterceptor = async function (r: any) {
+            return r;
+          };
+
+          let fired = false;
+          const rejectIntercept = function () {
+            fired = true;
+          };
+          axios.interceptors.response.use(unusedFulfillInterceptor, rejectIntercept);
+
+          try {
+            await axios.get('/get');
+          } catch (e) {
+            //
+          }
+          assert.equal(fired, true);
+        });
+
+        it('once caught, another following fulfill-interceptor is called again (just like in a promise chain)', async function () {
+          axios.interceptors.response.use(function () {
+            throw Error('throwing interceptor');
+          });
+
+          const unusedFulfillInterceptor = async function (r: any) {
+            return r;
+          };
+          const catchingThrowingInterceptor = function () {};
+          axios.interceptors.response.use(unusedFulfillInterceptor, catchingThrowingInterceptor);
+
+          let fired = false;
+          axios.interceptors.response.use(function interceptor3(res) {
+            fired = true;
+            return res;
+          });
+          try {
+            await axios.get('/get');
+          } catch (e) {
+            //
+          }
+          assert.equal(fired, true);
+        });
+      });
+    });
+  });
+
+  it('should allow removing interceptors', async function () {
+    let response: XiorResponse | undefined;
+
+    axios.interceptors.response.use(function (data) {
+      const resultData = data.data.method + '1';
+      return { ...data, data: resultData };
+    });
+    const intercept = axios.interceptors.response.use(function (data) {
+      data.data = data.data + '2';
+      return { ...data, data: data.data };
+    });
+    axios.interceptors.response.use(function (data) {
+      const resultData = data.data + '3';
+      return { ...data, data: resultData };
+    });
+
+    axios.interceptors.response.eject(intercept);
+
+    await axios.request('/get?a=123').then(function (data) {
+      response = data;
+    });
+    console.log('response.data', response);
+
+    assert.equal(response?.data, 'get13');
+  });
+
+  // it('should remove async interceptor before making request and execute synchronously', function (done) {
+  //   let asyncFlag = false;
+  //   const asyncIntercept = axios.interceptors.request.use(
+  //     function (config) {
+  //       config.headers.async = 'async it!';
+  //       return config;
+  //     },
+  //     null,
+  //     { synchronous: false }
+  //   );
+
+  //   const syncIntercept = axios.interceptors.request.use(
+  //     function (config) {
+  //       config.headers.sync = 'hello world';
+  //       expect(asyncFlag).toBe(false);
+  //       return config;
+  //     },
+  //     null,
+  //     { synchronous: true }
+  //   );
+
+  //   axios.interceptors.request.eject(asyncIntercept);
+
+  //   axios('/foo');
+  //   asyncFlag = true;
+
+  //   getAjaxRequest().then(function (request) {
+  //     expect(request.requestHeaders.async).toBeUndefined();
+  //     expect(request.requestHeaders.sync).toBe('hello world');
+  //     done();
+  //   });
+  // });
+
+  // it('should execute interceptors before transformers', async function () {
+  //   axios.interceptors.request.use(function (config) {
+  //     config.data.baz = 'qux';
+  //     return config;
+  //   });
+
+  //   const {config: request} = await  axios.post('/post', {
+  //     foo: 'bar',
+  //   });
+
+  //   getAjaxRequest().then(function (request) {
+  //     expect(request.params).toEqual('{"foo":"bar","baz":"qux"}');
+  //     ();
+  //   });
+  // });
+
+  it('should modify base URL in request interceptor', async function () {
+    const instance = xior.create({
+      baseURL: 'http://test.com/',
+    });
+
+    instance.interceptors.request.use(function (config) {
+      config.baseURL = baseURL;
+      return config;
+    });
+
+    await instance.get('/get').then(({ config: request }) => {
+      assert.equal(request.baseURL, baseURL);
+      assert.equal(request.url, '/get');
+    });
+  });
+
+  it('should clear all response interceptors', function () {
+    const instance = xior.create({
+      baseURL: 'http://test.com/',
+    });
+
+    instance.interceptors.response.use(function (config) {
+      return config;
+    });
+    instance.interceptors.response.clear();
+    assert.equal(instance.RESI, 0);
+  });
+});

--- a/tests/src/tests/plugins/error-retry.test.ts
+++ b/tests/src/tests/plugins/error-retry.test.ts
@@ -137,11 +137,12 @@ describe('xior error retry plugin tests', () => {
       (config) => {
         return config;
       },
-      () => {
+      (e) => {
         errorCount++;
         if (!S) {
           S = 'S123456';
         }
+        throw e;
       }
     );
 

--- a/tests/src/tests/polyfill.test.ts
+++ b/tests/src/tests/polyfill.test.ts
@@ -93,9 +93,8 @@ describe('xior polyfill tests', () => {
     });
 
     it('HEAD should work', async () => {
-      const { data, response } = await xiorInstance.head('/head', { params: { a: 1, b: 2 } });
-      assert.strictEqual(data, undefined);
-      assert.strictEqual(await response.text(), '');
+      const { data } = await xiorInstance.head('/head', { params: { a: 1, b: 2 } });
+      assert.strictEqual(data, '');
     });
     it('OPTIONS should work', async () => {
       const { data } = await xiorInstance.options<{


### PR DESCRIPTION
This will be a **breaking change** for `responseType: blob | arraybuffer` and multiple response interceptors, because behaviours is different than before.

Fix: https://github.com/suhaotian/xior/issues/12
Fix: https://github.com/suhaotian/xior/issues/15