### PR TITLE
fix: make `isXiorError` type guard

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,6 +118,6 @@ export class XiorTimeoutError<T = any> extends XiorError<T> {
   }
 }
 
-export function isXiorError(error: any) {
+export function isXiorError<T = any>(error: any): error is XiorError<T> | XiorTimeoutError<T> {
   return error?.name === XE || error?.name === XTE;
 }

--- a/tests/src/tests/plugins/error-retry.test.ts
+++ b/tests/src/tests/plugins/error-retry.test.ts
@@ -48,7 +48,7 @@ describe('xior error retry plugin tests', () => {
       } as any);
     } catch (e) {
       if (isXiorError(e)) {
-        error = e as XiorError;
+        error = e;
       }
     }
     assert.strictEqual(typeof error !== 'undefined', true);
@@ -63,7 +63,7 @@ describe('xior error retry plugin tests', () => {
       await instance.post('/retry-error', { count: 1 });
     } catch (e) {
       if (isXiorError(e)) {
-        error = e as XiorError;
+        error = e;
       }
     }
     assert.strictEqual(typeof error !== 'undefined', true);
@@ -110,7 +110,7 @@ describe('xior error retry plugin tests', () => {
       } as any);
     } catch (e) {
       if (isXiorError(e)) {
-        error = e as XiorError;
+        error = e;
       }
     }
     assert.strictEqual(typeof error !== 'undefined', true);
@@ -170,7 +170,7 @@ describe('xior error retry plugin tests', () => {
       msg = data.msg;
     } catch (e) {
       if (isXiorError(e)) {
-        error = e as XiorError;
+        error = e;
       }
     }
     assert.strictEqual((config as any).isRetry, true);
@@ -207,7 +207,7 @@ describe('xior error retry plugin tests', () => {
       } as any);
     } catch (e) {
       if (isXiorError(e)) {
-        error = e as XiorError;
+        error = e;
       }
     }
     assert.strictEqual(typeof error !== 'undefined', true);
@@ -236,7 +236,7 @@ describe('xior error retry plugin tests', () => {
       } as any);
     } catch (e) {
       if (isXiorError(e)) {
-        error = e as XiorError;
+        error = e;
       }
     }
     assert.strictEqual(typeof error !== 'undefined', true);


### PR DESCRIPTION
Currently, `isXiorError` returns just a boolean, which makes it necessary to manually make a type assertion to the `XiorError` ([example](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAD2NANHA3nAGsqBRKKVOYAZx2gKKjgF84AzIkOAciWlYG4AoHmKAE8MPOGLgBDAO4Tg8DlAB0AcwCmMABSsAFjBhhSALgD0x1QgngANqsUBjCCFYBKXvTsSYd7XA2rC0M4i4iQMvmQU+AFQftHOQeiiIeKmcP7UJKRwpDDAVlZw2hJZAAYArgB2ANYVEFIVJXAwgmCqcIC8G4BEe0nJadGKUKqkkBWktgAmnhK8PcmptVJwUtBVpGgARmXwEhVpCAIScCXF2LhU0I1kcBWqquN3Hd29YrEZJ5HnUAA8OVDAFcoAHzOAZDEZjAD8ikmMGms1ofBCqR2EBg2n8SxWEiIlXGGy2cA8FVq8DsZRyjmAAC82mjaS02gxoEcYRJGl1ZsAwq9mf8cjs7KoIGEPnFgs90tBQcMIKNVFDWbwQgjaEA)). This PR converts `isXiorError` to a type guard, so no more manually assertions are needed

P.S. Also, I removed no longer needed assertions in `error-retry` tests